### PR TITLE
General improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/traverse": "^7.0.0-beta.40",
     "@types/resolve-from": "0.0.18",
     "express": "^4.16.2",
+    "node-libs-browser": "^2.1.0",
     "resolve-from": "^4.0.0",
     "yargs": "^11.0.0"
   }

--- a/src/es6app.ts
+++ b/src/es6app.ts
@@ -1,5 +1,4 @@
 import * as express from 'express';
-import * as fs from 'fs';
 import * as path from 'path';
 import { Es6ischVfs, Es6isch } from './es6isch';
 import { transform } from './es6parse';

--- a/src/es6app.ts
+++ b/src/es6app.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-// import { es6isch } from './es6isch';
+import * as fs from 'fs';
 import * as path from 'path';
 import { Es6ischVfs, Es6isch } from './es6isch';
 import { transform } from './es6parse';
@@ -7,6 +7,11 @@ import { transform } from './es6parse';
 export function es6app(vfs: Es6ischVfs): express.Express {
   const app = express();
   app.use(vfs.es6ischBase, (req, res) => {
+    if (path.extname(req.url) === '.map') {
+      res.send('');
+      return;
+    }
+
     // const fsPath = `./${req.url}`;
     // console.log(fsPath, JSON.stringify(vfs, null, 2));
     res.setHeader('Content-type', 'application/javascript');

--- a/src/es6isch.ts
+++ b/src/es6isch.ts
@@ -115,7 +115,6 @@ export class Es6isch {
       }
       return new Es6isch(req, false, absResolved, redirected);
     } catch (e) {
-      console.log(req, map);
       console.error(e);
       return new Es6isch(req, true);
     }

--- a/src/es6isch.ts
+++ b/src/es6isch.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as resolveFrom from 'resolve-from';
 
 const Module = require('module');
+const nodeLibs = require('node-libs-browser');
 
 export function findPathOfPackageJson(str: string): string {
   if (str.length === 0) { return null; }
@@ -93,6 +94,7 @@ export class Es6isch {
   public readonly redirected: string;
   public readonly absResolved: string;
   public readonly req: Es6ischReq;
+  public readonly relResolved: string;
 
   public static fileResolv(req: Es6ischReq, map: Es6ischMap): Es6isch {
     try {
@@ -108,11 +110,13 @@ export class Es6isch {
       if (redirected.length > 0) {
         redirected = path.join(req.toResolv, redirected);
         if (!redirected.startsWith('.')) {
-          redirected = `${redirected}`;
+          redirected = `./${redirected}`;
         }
       }
       return new Es6isch(req, false, absResolved, redirected);
     } catch (e) {
+      console.log(req, map);
+      console.error(e);
       return new Es6isch(req, true);
     }
   }
@@ -136,7 +140,8 @@ export class Es6isch {
       for (let mdirIdx = 0; !fdir && mdirIdx < nmp.length; ++mdirIdx) {
         fdir = [
           path.join(nmp[mdirIdx], req.toResolv, 'package.json'),
-          path.join(nmp[mdirIdx], req.toResolv, 'index.js')
+          path.join(nmp[mdirIdx], req.toResolv, 'index.js'),
+          path.join(nmp[mdirIdx], `${req.toResolv}.js`)
         ].find(ndir => {
           // console.log(ndir);
           return fs.existsSync(ndir);
@@ -145,45 +150,26 @@ export class Es6isch {
       // console.log(`FOUND:${fdir}:${rootAbsPath}:${req.toResolv}`);
       // const modAbsPath = path.join(modMap.absBase, req.toResolv);
       // console.log(`resolve:${req.toResolv}:${rootAbsPath}:${req.vfs.root.absBase}`);
-      const absResolved = resolveFrom(rootAbsPath, req.toResolv);
-       let redirected = path.relative(rootAbsPath, absResolved)
-        .replace(/^[\.\/]+(\/node_modules\/.*)$/, '$1');
-      if (fdir) {
-        // console.log(`REDIRECT:${fdir}:${redirected}`);
-        let toTop = path.relative(rootAbsPath, req.vfs.root.absBase);
-        if (toTop.length == 0) {
-          toTop = '/';
-        }
-        redirected = path.join(toTop, redirected);
-      } else {
-        redirected = null;
+      const absResolved = nodeLibs[req.toResolv] || tryResolveFrom(rootAbsPath, req.toResolv);
+
+      if (!absResolved) {
+        throw new Error(`Could not resolve ${req.toResolv} from ${rootAbsPath}`);
       }
 
-      // // console.log(`redirected\n${toTop}\n${req.toResolv}\n${redirected}\n${rootAbsPath}\n${absResolved}`);
-      // console.log(redirected, absResolved, rootAbsPath);
-      // if (redirected.length == 0) {
-      //   // console.log(`STOP:REDIRECT`);
-      //   redirected = null; // path.join(toTop, redirected);
-      // // if (redirected.length > 0) {
-      // //   if (!redirected.startsWith('.')) {
-      // //     redirected = `./${redirected}`;
-      // //   }
-      // } else if (redirected.endsWith(req.toResolv)) {
-      //   // console.log(`DIRECT`);
-      //   redirected = null; // path.join(toTop, redirected);
-      // } else {
-      //   let toTop = path.relative(rootAbsPath, req.vfs.root.absBase);
-      //   if (toTop.length == 0) {
-      //     toTop = '/';
-      //   }
-      //   redirected = path.join(toTop, redirected);
-      //   // console.log(`NEEDS:REDIRECT:${toTop}:${redirected}`);
-      // }
-      // console.log(`redirected\n${redirected}:${absResolved}`);
-      return new Es6isch(req, false, absResolved, redirected);
+      const rewritten = path.relative(rootAbsPath, absResolved).replace(/^[\.\/]+(\/node_modules\/.*)$/, '$1');
+
+      const needsRedirect = typeof fdir === 'string';
+      let toTop = path.relative(rootAbsPath, req.vfs.root.absBase);
+      if (toTop.length == 0) {
+        toTop = '/';
+      }
+
+      const redirected = path.join(toTop, rewritten);
+      return needsRedirect
+        ? new Es6isch(req, false, absResolved, redirected)
+        : new Es6isch(req, false, absResolved, null, redirected);
     } catch (e) {
-      // console.log(e);
-      console.error(`can't find module:${req.toResolv}`);
+      console.error(e);
       return new Es6isch(req, true);
     }
   }
@@ -199,13 +185,22 @@ export class Es6isch {
   }
 
   public constructor(req: Es6ischReq, isError: boolean,
-    absResolved?: string, redirected?: string) {
+    absResolved?: string, redirected?: string, relResolved?: string) {
     this.req = req;
     this.isError = isError;
     this.absResolved = absResolved;
+    this.relResolved = relResolved;
     if (redirected && redirected.length > 0) {
       this.redirected = redirected;
     }
   }
 
+}
+
+function tryResolveFrom(from: string, id: string): string | null {
+  try {
+    return resolveFrom(from, id);
+  } catch (err) {
+    return null;
+  }
 }

--- a/src/es6parse.ts
+++ b/src/es6parse.ts
@@ -43,10 +43,11 @@ export function transform(res: Es6isch):  Es6Parsed {
   const resolved = Array.from(new Set(required)).map(toResolv => {
     return Es6isch.resolve(res.req.vfs, toResolv, res.req.toResolv);
   });
+
   return new Es6Parsed(res, [
-    resolved.map(r =>
-      `import * as require_${asVar(r.req.toResolv)} from '${r.redirected || r.req.toResolv}';`
-    ).join('\n'),
+    resolved.map(r => {
+      return `import * as require_${asVar(r.req.toResolv)} from '${r.redirected || r.relResolved}';`;
+    }).join('\n'),
     `const module = { exports: {} };`,
     `function require(fname) {`,
     `return ({`,

--- a/test/es6isch-test.ts
+++ b/test/es6isch-test.ts
@@ -246,8 +246,8 @@ describe('es6sich', () => {
         try {
           // console.log(res.body);
           assert.ok(200 <= res.statusCode && res.statusCode < 300);
-          assert.ok(res.body.startsWith(
-            'import * as require_react from \'react\';'
+          assert.ok(res.body.includes(
+            '// es6isch-project-level-pkg'
           ));
           done();
         } catch (e) {
@@ -261,8 +261,8 @@ describe('es6sich', () => {
         try {
           // console.log(res.body);
           assert.ok(200 <= res.statusCode && res.statusCode < 300);
-          assert.ok(res.body.startsWith(
-            'import * as require_react from \'react\';'
+          assert.ok(res.body.includes(
+            '// es6isch-project-level-pkg'
           ));
           done();
         } catch (e) {
@@ -277,8 +277,8 @@ describe('es6sich', () => {
           // console.log(res.statusCode);
           // console.log(res.body);
           assert.ok(200 <= res.statusCode && res.statusCode < 300);
-          assert.ok(res.body.startsWith(
-            'import * as require_doof from \'doof\';'
+          assert.ok(res.body.includes(
+            '// @patternplate/render-styled-compoments/mount.js'
           ));
           done();
         } catch (e) {

--- a/test/es6isch-test.ts
+++ b/test/es6isch-test.ts
@@ -45,14 +45,14 @@ describe('es6sich', () => {
       assert.equal(rv.isError, false, 'error');
       assert.equal(typeof (rv.absResolved), 'string');
       assert.equal(rv.absResolved, path.join(vfs.root.absBase, 'base', 'wurst', 'index.js'));
-      assert.equal(rv.redirected, 'base/wurst/index.js');
+      assert.equal(rv.redirected, './base/wurst/index.js');
     });
     it('resolve index.js + redirect', () => {
       const rv = Es6isch.resolve(vfs, './base/wurst/reactPackage');
       assert.equal(rv.isError, false, 'error');
       assert.equal(rv.absResolved,
         path.join(vfs.root.absBase, 'base', 'wurst', 'reactPackage', 'index.js'), 'abs');
-      assert.equal(rv.redirected, 'base/wurst/reactPackage/index.js', 'redirect');
+      assert.equal(rv.redirected, './base/wurst/reactPackage/index.js', 'redirect');
     });
     it('resolve index.js + no redirect', () => {
       const rv = Es6isch.resolve(vfs, './base/wurst/reactPackage/index.js');
@@ -67,7 +67,7 @@ describe('es6sich', () => {
       assert.equal(rv.isError, false, 'error');
       assert.equal(rv.absResolved,
         path.join(vfs.root.absBase, 'base', 'wurst', 'reactPackage', 'index.js'), 'abs');
-      assert.equal(rv.redirected, 'index.js', 'redirect');
+      assert.equal(rv.redirected, './index.js', 'redirect');
     });
 
     it('resolve:base index.js + no redirect', () => {
@@ -83,7 +83,7 @@ describe('es6sich', () => {
       assert.equal(rv.isError, false, 'error');
       assert.equal(rv.absResolved,
         path.join(vfs.root.absBase, 'base', 'wurst', 'reactPackage', 'index.js'), 'abs');
-      assert.equal(rv.redirected, 'index.js', 'redirect');
+      assert.equal(rv.redirected, './index.js', 'redirect');
     });
 
     it('resolve:base-file index.js + no redirect', () => {

--- a/test/pkgbase/render-styled-compoments/mount.js
+++ b/test/pkgbase/render-styled-compoments/mount.js
@@ -1,2 +1,1 @@
-
-const doof = require('doof');
+// @patternplate/render-styled-compoments/mount.js

--- a/test/projectBase/node_modules/projectlevelpkg/test.js
+++ b/test/projectBase/node_modules/projectlevelpkg/test.js
@@ -1,1 +1,1 @@
-const react = require('react');
+// es6isch-project-level-pkg


### PR DESCRIPTION
* ensure relative module identifiers
* support node builtins

--- 
There are still some issue around unresolvable modules and `es6isch` swallowing **all** errors. I think throwing for errors should be the default